### PR TITLE
feat: update code to support multi-day responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,17 +17,44 @@ Dado que ahora es requerido enviar el correo electrónico y el token asignado en
 Obtener el tipo de cambio del dólar del día actual:
 
 ```javascript
-indicadoresEconomicosBCCR.get(EMAIL, TOKEN).then(tipoDeCambio => {
-  // { compra: 500.00, venta: 500.00 }
+indicadoresEconomicosBCCR(EMAIL, TOKEN).then((TC) => {
+  // {
+  //   '2022-04-08T00:00:00-06:00': {
+  //     compra: { fecha: '2022-04-08T00:00:00-06:00', valor: 654.24 },
+  //     venta: { fecha: '2022-04-08T00:00:00-06:00', valor: 661.64 }
+  //   }
+  // }
 });
 ```
 
 Obtener el tipo de cambio del dólar de una fecha de inicio a una fecha final:
 
 ```javascript
-indicadoresEconomicosBCCR(EMAIL, TOKEN, "01/01/2018", "02/01/2018").then(
-  tipoDeCambio => {
-    // { compra: 500.00, venta: 500.00 }
+// formate de la fecha: DD/MM/YYYY
+indicadoresEconomicosBCCR(EMAIL, TOKEN, '20/04/2018', '24/04/2018').then(
+  (TC) => {
+    //    {
+    //   '2018-04-20T00:00:00-06:00': {
+    //     compra: { fecha: '2018-04-20T00:00:00-06:00', valor: 561.21 },
+    //     venta: { fecha: '2018-04-20T00:00:00-06:00', valor: 566.82 }
+    //   },
+    //   '2018-04-21T00:00:00-06:00': {
+    //     compra: { fecha: '2018-04-21T00:00:00-06:00', valor: 561.27 },
+    //     venta: { fecha: '2018-04-21T00:00:00-06:00', valor: 567.64 }
+    //   },
+    //   '2018-04-22T00:00:00-06:00': {
+    //     compra: { fecha: '2018-04-22T00:00:00-06:00', valor: 561.27 },
+    //     venta: { fecha: '2018-04-22T00:00:00-06:00', valor: 567.64 }
+    //   },
+    //   '2018-04-23T00:00:00-06:00': {
+    //     compra: { fecha: '2018-04-23T00:00:00-06:00', valor: 561.27 },
+    //     venta: { fecha: '2018-04-23T00:00:00-06:00', valor: 567.64 }
+    //   },
+    //   '2018-04-24T00:00:00-06:00': {
+    //     compra: { fecha: '2018-04-24T00:00:00-06:00', valor: 560.66 },
+    //     venta: { fecha: '2018-04-24T00:00:00-06:00', valor: 567.56 }
+    //   }
+    // }
   }
 );
 ```

--- a/lib/indicadoresEconomicosBCCR.js
+++ b/lib/indicadoresEconomicosBCCR.js
@@ -1,43 +1,89 @@
 'use strict';
 
-var axios = require('axios');
-var querystring = require('querystring');
-var DOMParser = require('xmldom').DOMParser;
+const axios = require('axios');
+const querystring = require('querystring');
+const DOMParser = require('xmldom').DOMParser;
 
 module.exports.default = indicadoresEconomicosBCCR;
 module.exports = indicadoresEconomicosBCCR;
 
 function indicadoresEconomicosBCCR(email, token, fechaInicio, fechaFinal) {
-    try {
-        var todayDate = new Date();
-        var BCCRurl = 'https://gee.bccr.fi.cr/Indicadores/Suscripciones/WS/wsindicadoreseconomicos.asmx/ObtenerIndicadoresEconomicos';
-        var payload = {
-            FechaInicio: fechaInicio ? fechaInicio : todayDate.getDate() + "/" + (todayDate.getMonth() + 1) + "/" + todayDate.getFullYear(),
-            FechaFinal: fechaFinal ? fechaFinal : todayDate.getDate() + "/" + (todayDate.getMonth() + 1) + "/" + todayDate.getFullYear(),
-            Nombre: 'N',
-            SubNiveles: 'N',
-            Indicador: 317,
-            CorreoElectronico: email,
-            Token: token,
-        };
-        var postCompra = axios.post(BCCRurl, querystring.stringify(payload));
+  try {
+    const todayDate = new Date();
+    const BCCRurl =
+      'https://gee.bccr.fi.cr/Indicadores/Suscripciones/WS/wsindicadoreseconomicos.asmx/ObtenerIndicadoresEconomicos';
+    const payload = {
+      FechaInicio: fechaInicio
+        ? fechaInicio
+        : todayDate.getDate() +
+          '/' +
+          (todayDate.getMonth() + 1) +
+          '/' +
+          todayDate.getFullYear(),
+      FechaFinal: fechaFinal
+        ? fechaFinal
+        : todayDate.getDate() +
+          '/' +
+          (todayDate.getMonth() + 1) +
+          '/' +
+          todayDate.getFullYear(),
+      Nombre: 'N',
+      SubNiveles: 'N',
+      Indicador: 317,
+      CorreoElectronico: email,
+      Token: token,
+    };
+    const postCompra = axios.post(BCCRurl, querystring.stringify(payload));
 
-        payload.Indicador = 318;
+    payload.Indicador = 318;
 
-        var postVenta = axios.post(BCCRurl, querystring.stringify(payload));
+    const postVenta = axios.post(BCCRurl, querystring.stringify(payload));
 
-        return axios.all([postCompra, postVenta]).then(axios.spread(function (compra, venta) {
-            var compraNode = new DOMParser().parseFromString(compra.data, 'text/xml');
-            var ventaNode = new DOMParser().parseFromString(venta.data, 'text/xml'); 
+    return axios.all([postCompra, postVenta]).then(
+      axios.spread(function (compra, venta) {
+        const compraNode = new DOMParser().parseFromString(
+          compra.data,
+          'text/xml'
+        );
+        const ventaNode = new DOMParser().parseFromString(
+          venta.data,
+          'text/xml'
+        );
 
-            return {
-                'compra': Math.pow(parseFloat(compraNode.documentElement.getElementsByTagName('NUM_VALOR')[0].childNodes[0].nodeValue).toFixed(2), 1),
-                'venta': Math.pow(parseFloat(ventaNode.documentElement.getElementsByTagName('NUM_VALOR')[0].childNodes[0].nodeValue).toFixed(2), 1)
-            };
-        }));
+        const data = {};
 
-    } catch (error) {
-        throw new Error(error);
-    }
+        for (
+          let i = 0;
+          i < compraNode.getElementsByTagName('NUM_VALOR').length;
+          i++
+        ) {
+          let compraValue =
+            compraNode.getElementsByTagName('NUM_VALOR')[i].textContent;
+          let ventaValue =
+            ventaNode.getElementsByTagName('NUM_VALOR')[i].textContent;
+          let compraDate =
+            compraNode.getElementsByTagName('DES_FECHA')[i].textContent;
+          let ventaDate =
+            ventaNode.getElementsByTagName('DES_FECHA')[i].textContent;
+          let compra = {
+            fecha: compraDate,
+            valor: Math.pow(parseFloat(compraValue).toFixed(2), 1),
+          };
+          let venta = {
+            fecha: ventaDate,
+            valor: Math.pow(parseFloat(ventaValue).toFixed(2), 1),
+          };
 
-};
+          data[compraDate] = {
+            compra,
+            venta,
+          };
+        }
+
+        return data;
+      })
+    );
+  } catch (error) {
+    throw new Error(error);
+  }
+}

--- a/test.js
+++ b/test.js
@@ -1,11 +1,11 @@
 const indicadoresEconomicosBCCR = require('./index');
 
 indicadoresEconomicosBCCR().then((data) => {
-    console.log("Compra y Venta del día de hoy:");
-    console.log(data);
+  console.log('Compra y Venta del día de hoy:');
+  console.log(data);
 });
 
-indicadoresEconomicosBCCR('20/04/2018', '20/04/2018').then((data) => {
-    console.log("Compra y Venta por fecha:");
-    console.log(data);
+indicadoresEconomicosBCCR('20/04/2018', '24/04/2018').then((data) => {
+  console.log('Compra y Venta por fecha:');
+  console.log(data);
 });


### PR DESCRIPTION
He actualizado la libreria para que permita mostrar multiples pares de tipo de cambio cuando se envia una solicitud entre dos fechas que no son el mismo dia. Actualmente la libreria solo muestra el tipo de cambio que se encuentra en la posicion 0 del la respuesta.